### PR TITLE
Remove margin bottom for page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -232,7 +232,6 @@ img:-moz-loading {
 .main {
   flex: 1;
   padding-top: var(--space-l);
-  margin-bottom: var(--space-xl);
 }
 
 .intro {


### PR DESCRIPTION
This removes the margin bottom from the .main css class on desktop displays.
