### PR TITLE
Add "Donate" button for hebasto

### DIFF
--- a/donatees/hennadii-stepanov.json
+++ b/donatees/hennadii-stepanov.json
@@ -2,8 +2,9 @@
   "name": "Hennadii Stepanov",
   "github": "hebasto",
   "twitter": "hhebasto",
+  "donate": "https://github.com/hebasto",
   "avatar": "https://avatars0.githubusercontent.com/u/32963518?s=460&u=7297e8aaf9188c0cb98bc549a8a02a1dc8d59e4c&v=4",
-  "description": "I've been contributing to Bitcoin Core since mid 2018. Focused on build system, GUI and P2P.",
+  "description": "I've been contributing to Bitcoin Core since mid 2018. Focused on build system, GUI and P2P. For donations please use a BTC address from my GitHub profile until GitHub Sponsors becomes available in Ukraine.",
   "tags": [
     "Bitcoin Core"
   ]


### PR DESCRIPTION
Since GitHub Sponsors is [not available](https://github.com/sponsors#regions) in Ukraine the relevant comment added.