### PR TITLE
Remove Steve Schellbach (no ACK)

### DIFF
--- a/donatees/steve-schellbach.json
+++ b/donatees/steve-schellbach.json
@@ -1,8 +1,0 @@
-{
-  "name": "Steve Schellbach",
-  "github": "Coinward",
-  "twitter": "Coinward",
-  "donate": "https://github.com/sponsors/coinward",
-  "avatar": "https://pbs.twimg.com/profile_images/1284940049579012096/PpoNyvPp_200x200.jpg",
-  "description": "Focused on mobile wallet development and Bitcoin native services that can scale to billions of users."
-}


### PR DESCRIPTION
Removing Steve for now as there was no ACK when merging. We are still figuring out what a good policy for merging looks like, for now we are requiring at least one ACK/endorsement for the person to get listed.